### PR TITLE
docs: add development pause notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # oh-my-openclaw
 
+> ⚠️ **Notice**: Development is temporarily paused due to limited availability.
+> The project will remain as-is under the MIT license. Contributions are still welcome.
+
 OpenClaw configuration preset manager.
 
 ## What is this?

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # oh-my-openclaw
 
 > ⚠️ **Notice**: Development is temporarily paused due to limited availability.
-> The project will remain as-is under the MIT license. Contributions are still welcome.
+> The project will remain as-is under the MIT license.
+> Contributions are still welcome, but please expect delays in review and merging.
 
 OpenClaw configuration preset manager.
 


### PR DESCRIPTION
## Summary
Add a notice to the README indicating that development is temporarily paused due to limited availability.

## Changes
- Added prominent notice at the top of README explaining development is on hold
- Clarified that the project remains available under MIT license
- Noted that contributions are still welcome

## Impact
Informs users and potential contributors about the current maintenance status of the project.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a prominent notice at the top of the README stating development is temporarily paused. Clarifies the project remains MIT-licensed and contributions are still welcome.

<sup>Written for commit 8a80744630cf513f5194dc354060af28be333808. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

