### PR TITLE
chore: add dependabot.yml for npm and GitHub Actions auto-updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  - package-ecosystem: "npm"
+  - package-ecosystem: "bun"
     directory: "/"
     schedule:
       interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    assignees:
+      - "minpeter"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    assignees:
+      - "minpeter"


### PR DESCRIPTION
## What changed

Added `.github/dependabot.yml` to configure Dependabot for two package ecosystems:
- **npm**: weekly checks for package dependency updates in the project root
- **github-actions**: weekly checks for GitHub Actions version updates in workflows

## Why

The repository has active npm dependencies and multiple GitHub Actions workflow steps (in `code-quality.yml` and `release.yml`), but no Dependabot configuration. Without it, dependency updates — including security patches — require manual effort to discover and apply.

This change is zero-risk: Dependabot only opens PRs, it never merges or modifies code automatically. The only effect is receiving automated PRs when newer versions are available.

## Verification

The file was verified to:
1. Contain valid YAML structure (parsed successfully via Python content validation and Node.js)
2. Include both `npm` and `github-actions` package ecosystems
3. Set `weekly` schedule and assign PRs to the repo owner (`minpeter`)

---
*This is an automated maintenance pass. The change is minimal and non-breaking.*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `.github/dependabot.yml` to enable weekly update PRs for `bun` dependencies and `github-actions` versions from the repo root. PRs will be assigned to `minpeter`.

<sup>Written for commit 4a80e274827f0f333c5269b4c3f90e1b265b4b35. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/oh-my-openclaw/pull/4?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

